### PR TITLE
delete NRIC command

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -8,6 +8,7 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
+    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_NRIC = "The person NRIC provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
 
 }

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -42,19 +42,6 @@ public class DeleteCommand extends Command {
         List<Patient> lastShownList = model.getFilteredPersonList();
         Patient patientToDelete;
 
-//        if (targetIndex != null) {
-//            if (targetIndex.getZeroBased() >= lastShownList.size()) {
-//                throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
-//            }
-//            patientToDelete = lastShownList.get(targetIndex.getZeroBased());
-//        } else {
-//            model.updateFilteredPersonList(x -> x.getNric().equals(targetNric));
-//            if (model.count() != 1) {
-//                throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_NRIC);
-//            }
-//            patientToDelete = model.getFilteredPersonList().get(0);
-//        }
-
         if (targetNric != null) {
             model.updateFilteredPersonList(patient -> patient.getNric().equals(targetNric));
             if (model.getFilteredPersonList().size() != 1) {

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -8,6 +8,7 @@ import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.patient.Nric;
 import seedu.address.model.patient.Patient;
 
 /**
@@ -24,22 +25,49 @@ public class DeleteCommand extends Command {
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
 
-    private final Index targetIndex;
+    private Index targetIndex;
+    private Nric targetNric;
 
     public DeleteCommand(Index targetIndex) {
         this.targetIndex = targetIndex;
+    }
+
+    public DeleteCommand(Nric targetNric) {
+        this.targetNric = targetNric;
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         List<Patient> lastShownList = model.getFilteredPersonList();
+        Patient patientToDelete;
 
-        if (targetIndex.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+//        if (targetIndex != null) {
+//            if (targetIndex.getZeroBased() >= lastShownList.size()) {
+//                throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+//            }
+//            patientToDelete = lastShownList.get(targetIndex.getZeroBased());
+//        } else {
+//            model.updateFilteredPersonList(x -> x.getNric().equals(targetNric));
+//            if (model.count() != 1) {
+//                throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_NRIC);
+//            }
+//            patientToDelete = model.getFilteredPersonList().get(0);
+//        }
+
+        if (targetNric != null) {
+            model.updateFilteredPersonList(patient -> patient.getNric().equals(targetNric));
+            if (model.getFilteredPersonList().size() != 1) {
+                throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_NRIC);
+            }
+            patientToDelete = model.getFilteredPersonList().get(0);
+        } else {
+            if (targetIndex.getZeroBased() >= lastShownList.size()) {
+                throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+            }
+            patientToDelete = lastShownList.get(targetIndex.getZeroBased());
         }
 
-        Patient patientToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deletePerson(patientToDelete);
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, patientToDelete));
     }

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -5,6 +5,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.patient.Nric;
 
 /**
  * Parses input arguments and creates a new DeleteCommand object
@@ -18,8 +19,13 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
      */
     public DeleteCommand parse(String args) throws ParseException {
         try {
-            Index index = ParserUtil.parseIndex(args);
-            return new DeleteCommand(index);
+            if (Nric.isValidNric(args)) {
+                Nric nric = ParserUtil.parseNric(args.trim());
+                return new DeleteCommand(nric);
+            } else {
+                Index index = ParserUtil.parseIndex(args);
+                return new DeleteCommand(index);
+            }
         } catch (ParseException pe) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);

--- a/src/main/java/seedu/address/model/patient/Nric.java
+++ b/src/main/java/seedu/address/model/patient/Nric.java
@@ -28,7 +28,7 @@ public class Nric {
      * Returns true if a given string is a valid phone number.
      */
     public static boolean isValidNric(String test) {
-        return test.matches(VALIDATION_REGEX);
+        return test.trim().matches(VALIDATION_REGEX);
     }
 
     @Override


### PR DESCRIPTION
Edit delete command to be able to delete by NRIC.
Delete command now has an additional functionality, to be able to delete by NRIC, in addition to just deleting by index originally.